### PR TITLE
Add missing php dependencies for nginx image

### DIFF
--- a/Dockerfile.nginx-amd64
+++ b/Dockerfile.nginx-amd64
@@ -18,8 +18,11 @@ LABEL website="http://sabre.io/baikal/"
 
 # Install dependencies: PHP & SQLite3
 RUN apt-get update && apt-get install -y \
+    php7.0-dom \
     php7.0-fpm \
+    php7.0-mbstring \
     php7.0-sqlite \
+    php7.0-xmlwriter \
     sqlite3 \
   && rm -rf /var/lib/apt/lists/* \
   && sed -i 's/www-data/nginx/' /etc/php/7.0/fpm/pool.d/www.conf

--- a/Dockerfile.nginx-arm32v7
+++ b/Dockerfile.nginx-arm32v7
@@ -18,8 +18,11 @@ LABEL website="http://sabre.io/baikal/"
 
 # Install dependencies: PHP & SQLite3
 RUN apt-get update && apt-get install -y \
+    php7.0-dom \
     php7.0-fpm \
+    php7.0-mbstring \
     php7.0-sqlite \
+    php7.0-xmlwriter \
     sqlite3 \
   && rm -rf /var/lib/apt/lists/* \
   && sed -i 's/www-data/nginx/' /etc/php/7.0/fpm/pool.d/www.conf


### PR DESCRIPTION
Without these dependencies, baikal cannot be used.