### PR TITLE
Fix curl call in systemd guide

### DIFF
--- a/docs/systemd-guide.md
+++ b/docs/systemd-guide.md
@@ -3,7 +3,7 @@
 To ensure Baikal is up after reboots, I also included a [Systemd service template](https://github.com/ckulka/baikal-docker/blob/master/baikal.service) which relies on the Docker Compose file to start all containers. Before you use it, make sure that the working directory matches your server setup.
 
 ```bash
-sudo curl -o /etc/systemd/system/baikal.service https://github.com/ckulka/baikal-docker/blob/master/baikal.service
+sudo curl -o /etc/systemd/system/baikal.service https://raw.githubusercontent.com/ckulka/baikal-docker/master/baikal.service
 # Adjust the WorkingDirectory variable
 
 sudo systemctl enable baikal.service


### PR DESCRIPTION
When using the command shown currently on the guide, HTML will be output to the unit file. This commits changes the line so it downloads the file correctly.