### PR TITLE
Features/mail -- move msmtp install to final image

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If you want to use local folders instead of Docker volumes, see [examples/docker
 
 You can find more installation and configuration guides here:
 
+- [Email Guide](https://github.com/ckulka/baikal-docker/blob/master/docs/email-guide.md)
 - [SSL Certificate Guide](https://github.com/ckulka/baikal-docker/blob/master/docs/ssl-certificates-guide.md)
 - [systemd Guide](https://github.com/ckulka/baikal-docker/blob/master/docs/systemd-guide.md)
 - [Unraid Installation Guide](https://github.com/ckulka/baikal-docker/blob/master/docs/unraid-installation-guide.md)

--- a/apache-php8.0.dockerfile
+++ b/apache-php8.0.dockerfile
@@ -18,13 +18,16 @@ LABEL website="http://sabre.io/baikal/"
 COPY --from=builder baikal /var/www/baikal
 RUN chown -R www-data:www-data /var/www/baikal      &&\
   apt-get update                                    &&\
-  apt-get install -y libcurl4-openssl-dev sendmail  &&\
+  apt-get install -y libcurl4-openssl-dev           &&\
   rm -rf /var/lib/apt/lists/*                       &&\
   docker-php-ext-install curl pdo pdo_mysql
 
 # Configure Apache + HTTPS
 COPY files/apache.conf /etc/apache2/sites-enabled/000-default.conf
-RUN a2enmod rewrite ssl && openssl req -x509 -newkey rsa:2048 -subj "/C=  " -keyout /etc/ssl/private/baikal.private.pem -out /etc/ssl/private/baikal.public.pem -days 3650 -nodes
+RUN apt update \
+ && apt install -y \
+    msmtp msmtp-mta \
+ && a2enmod rewrite ssl && openssl req -x509 -newkey rsa:2048 -subj "/C=  " -keyout /etc/ssl/private/baikal.private.pem -out /etc/ssl/private/baikal.public.pem -days 3650 -nodes
 
 # Expose HTTPS & data directory
 EXPOSE 443

--- a/apache.dockerfile
+++ b/apache.dockerfile
@@ -18,13 +18,16 @@ LABEL website="http://sabre.io/baikal/"
 COPY --from=builder baikal /var/www/baikal
 RUN chown -R www-data:www-data /var/www/baikal            &&\
   apt-get update                                          &&\
-  apt-get install -y libcurl4-openssl-dev msmtp msmtp-mta &&\
+  apt-get install -y libcurl4-openssl-dev                 &&\
   rm -rf /var/lib/apt/lists/*                             &&\
   docker-php-ext-install curl pdo pdo_mysql
 
 # Configure Apache + HTTPS
 COPY files/apache.conf /etc/apache2/sites-enabled/000-default.conf
-RUN a2enmod rewrite ssl && openssl req -x509 -newkey rsa:2048 -subj "/C=  " -keyout /etc/ssl/private/baikal.private.pem -out /etc/ssl/private/baikal.public.pem -days 3650 -nodes
+RUN apt update \
+ && apt install -y \
+    msmtp msmtp-mta \
+ && a2enmod rewrite ssl && openssl req -x509 -newkey rsa:2048 -subj "/C=  " -keyout /etc/ssl/private/baikal.private.pem -out /etc/ssl/private/baikal.public.pem -days 3650 -nodes
 
 # Expose HTTPS & data directory
 EXPOSE 443

--- a/apache.dockerfile
+++ b/apache.dockerfile
@@ -7,7 +7,7 @@ ADD https://github.com/sabre-io/Baikal/releases/download/$VERSION/baikal-$VERSIO
 RUN apk add unzip && unzip -q baikal-$VERSION.zip
 
 # Final Docker image
-FROM php:8.1-apache
+FROM php:8.0-apache
 
 LABEL description="Baikal is a Cal and CardDAV server, based on sabre/dav, that includes an administrative interface for easy management."
 LABEL version="0.9.1"
@@ -16,10 +16,10 @@ LABEL website="http://sabre.io/baikal/"
 
 # Install Baikal and required dependencies
 COPY --from=builder baikal /var/www/baikal
-RUN chown -R www-data:www-data /var/www/baikal      &&\
-  apt-get update                                    &&\
-  apt-get install -y libcurl4-openssl-dev sendmail  &&\
-  rm -rf /var/lib/apt/lists/*                       &&\
+RUN chown -R www-data:www-data /var/www/baikal            &&\
+  apt-get update                                          &&\
+  apt-get install -y libcurl4-openssl-dev msmtp msmtp-mta &&\
+  rm -rf /var/lib/apt/lists/*                             &&\
   docker-php-ext-install curl pdo pdo_mysql
 
 # Configure Apache + HTTPS
@@ -31,5 +31,5 @@ EXPOSE 443
 VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific
 
-COPY files/start.sh /opt
-CMD [ "sh", "/opt/start.sh" ]
+COPY files/start-*.sh /opt
+CMD /opt/start-apache.sh

--- a/docs/email-guide.md
+++ b/docs/email-guide.md
@@ -1,0 +1,72 @@
+# Email Guide
+
+This guide outlines the email configuration so that you can send out email invitations. Many thanks to [@philippneugebauer](https://github.com/philippneugebauer), [@vaskozl](https://github.com/vaskozl), and everyone in [#61](https://github.com/ckulka/baikal-docker/discussions/61) for contributing.
+
+In order to send out emails, you need a working SMTP service - you can host your own or rely on a service such as [Gmail](https://support.google.com/mail/answer/7126229?hl=en#zippy=%2Cstep-change-smtp-other-settings-in-your-email-client).
+
+The entire email configuration is stored in the `MSMTPRC` environment variable.
+
+## Generic SMTP server
+
+If you have an SMTP server without security in place, i.e. no authentication or SSL/TLS/STARTTLS, then you only have to configure the SMTP server name. Needless to say it's highly recommended to have authentication and TLS in place.
+
+```yaml
+services:
+  baikal:
+    image: ckulka/baikal:nginx
+    environment:
+      MSMTPRC: |
+        defaults
+        account        default
+        host           <smtp host>
+        port           25
+```
+
+If you have TLS and authentication in place, add the following configuration parameters:
+
+```yaml
+services:
+  baikal:
+    image: ckulka/baikal:nginx
+    restart: always
+    environment:
+      MSMTPRC: |
+        defaults
+        auth           on
+        tls            on
+        tls_trust_file /etc/ssl/certs/ca-certificates.crt
+        account        default
+        host           <smtp host>
+        port           587
+        from           baikal@example.com
+        user           <user>
+        password       <password>
+```
+
+See [examples/docker-compose.email.yaml](../examples/docker-compose.email.yaml) for a starter template.
+
+## Gmail
+
+If you use Gmail as your SMTP server, you have to first allow less secure apps (sendmail) to use Gmail, see [Less secure apps & your Google Account](https://support.google.com/accounts/answer/6010255?hl=en#zippy=).
+
+Once that is done, use the following configuration:
+
+```yaml
+services:
+  baikal:
+    image: ckulka/baikal:nginx
+    environment:
+      MSMTPRC: |
+        defaults
+        auth           on
+        tls            on
+        tls_trust_file /etc/ssl/certs/ca-certificates.crt
+        account        default
+        host           smtp.gmail.com
+        port           587
+        from           <user>@gmail.com
+        user           <user>
+        password       <password>
+```
+
+See [examples/docker-compose.sendmail-gmail.yaml](../examples/docker-compose.email-gmail.yaml) for a starter template.

--- a/examples/docker-compose.email-gmail.yaml
+++ b/examples/docker-compose.email-gmail.yaml
@@ -1,0 +1,29 @@
+# Docker Compose file for a Baikal server
+# See https://github.com/ckulka/baikal-docker/blob/master/docs/email-guide.md
+
+version: "2"
+services:
+  baikal:
+    image: ckulka/baikal:nginx
+    restart: always
+    environment:
+      MSMTPRC: |
+        defaults
+        auth           on
+        tls            on
+        tls_trust_file /etc/ssl/certs/ca-certificates.crt
+        account        default
+        host           smtp.gmail.com
+        port           587
+        from           <user>@gmail.com
+        user           <user>
+        password       <password>
+    ports:
+      - "80:80"
+    volumes:
+      - config:/var/www/baikal/config
+      - data:/var/www/baikal/Specific
+
+volumes:
+  config:
+  data:

--- a/examples/docker-compose.email.yaml
+++ b/examples/docker-compose.email.yaml
@@ -1,0 +1,29 @@
+# Docker Compose file for a Baikal server
+# See https://github.com/ckulka/baikal-docker/blob/master/docs/email-guide.md
+
+version: "2"
+services:
+  baikal:
+    image: ckulka/baikal:nginx
+    restart: always
+    environment:
+      MSMTPRC: |
+        defaults
+        auth           on
+        tls            on
+        tls_trust_file /etc/ssl/certs/ca-certificates.crt
+        account        default
+        host           <smtp host>
+        port           587
+        from           baikal@example.com
+        user           <user>
+        password       <password>
+    ports:
+      - "80:80"
+    volumes:
+      - config:/var/www/baikal/config
+      - data:/var/www/baikal/Specific
+
+volumes:
+  config:
+  data:

--- a/files/start-apache.sh
+++ b/files/start-apache.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+/opt/start-msmtp.sh
+
 # Inject ServerName and ServerAlias if specified
 APACHE_CONFIG="/etc/apache2/sites-available/000-default.conf"
 if [ ! -z ${BAIKAL_SERVERNAME+x} ]

--- a/files/start-msmtp.sh
+++ b/files/start-msmtp.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# See https://github.com/ckulka/baikal-docker/discussions/61
+
+# Insert sendmail mailer definitions
+if [ ! -z ${MSMTPRC+x} ]
+then
+  echo "$MSMTPRC" > /etc/msmtprc
+  chown root:msmtp /etc/msmtprc
+  chmod 640 /etc/msmtprc
+fi

--- a/files/start-nginx.sh
+++ b/files/start-nginx.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+/opt/start-msmtp.sh
+
+/etc/init.d/php8.0-fpm start
+chown -R nginx:nginx /var/www/baikal/Specific
+nginx -g "daemon off;"

--- a/nginx-php8.0.dockerfile
+++ b/nginx-php8.0.dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build, see https://docs.docker.com/develop/develop-images/multistage-build/
 FROM alpine AS builder
 
-ENV VERSION 0.9.1
+ENV VERSION 0.9.2
 
 ADD https://github.com/sabre-io/Baikal/releases/download/$VERSION/baikal-$VERSION.zip .
 RUN apk add unzip && unzip -q baikal-$VERSION.zip
@@ -10,7 +10,7 @@ RUN apk add unzip && unzip -q baikal-$VERSION.zip
 FROM nginx:1
 
 LABEL description="Baikal is a Cal and CardDAV server, based on sabre/dav, that includes an administrative interface for easy management."
-LABEL version="0.9.1"
+LABEL version="0.9.2"
 LABEL repository="https://github.com/ckulka/baikal-docker"
 LABEL website="http://sabre.io/baikal/"
 
@@ -36,8 +36,13 @@ RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 
 # Add Baikal & nginx configuration
 COPY --from=builder baikal /var/www/baikal
-RUN chown -R nginx:nginx /var/www/baikal
+RUN apt update \
+ && apt install -y \
+    msmtp msmtp-mta \
+ && rm -rf /var/lib/apt/lists/* \
+ && chown -R nginx:nginx /var/www/baikal
 COPY files/nginx.conf /etc/nginx/conf.d/default.conf
+COPY files/start*.sh /opt/
 
 VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific

--- a/nginx-php8.0.dockerfile
+++ b/nginx-php8.0.dockerfile
@@ -28,8 +28,7 @@ RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
     php8.0-mysql              \
     php8.0-sqlite3            \
     php8.0-xml                \
-    sqlite3                   \
-    sendmail                  &&\
+    sqlite3                   &&\
   rm -rf /var/lib/apt/lists/* &&\
   sed -i 's/www-data/nginx/' /etc/php/8.0/fpm/pool.d/www.conf &&\
   sed -i 's/^listen = .*/listen = \/var\/run\/php-fpm.sock/' /etc/php/8.0/fpm/pool.d/www.conf

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -22,23 +22,24 @@ RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
   apt remove -y lsb-release   &&\
   apt update                  &&\
     apt install -y            \
-    php8.1-curl               \
-    php8.1-fpm                \
-    php8.1-mbstring           \
-    php8.1-mysql              \
-    php8.1-sqlite3            \
-    php8.1-xml                \
+    php8.0-curl               \
+    php8.0-fpm                \
+    php8.0-mbstring           \
+    php8.0-mysql              \
+    php8.0-sqlite3            \
+    php8.0-xml                \
     sqlite3                   \
-    sendmail                  &&\
+    msmtp msmtp-mta           &&\
   rm -rf /var/lib/apt/lists/* &&\
-  sed -i 's/www-data/nginx/' /etc/php/8.1/fpm/pool.d/www.conf &&\
-  sed -i 's/^listen = .*/listen = \/var\/run\/php-fpm.sock/' /etc/php/8.1/fpm/pool.d/www.conf
+  sed -i 's/www-data/nginx/' /etc/php/8.0/fpm/pool.d/www.conf &&\
+  sed -i 's/^listen = .*/listen = \/var\/run\/php-fpm.sock/' /etc/php/8.0/fpm/pool.d/www.conf
 
 # Add Baikal & nginx configuration
 COPY --from=builder baikal /var/www/baikal
 RUN chown -R nginx:nginx /var/www/baikal
 COPY files/nginx.conf /etc/nginx/conf.d/default.conf
+COPY files/start*.sh /opt/
 
 VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific
-CMD /etc/init.d/php8.1-fpm start && chown -R nginx:nginx /var/www/baikal/Specific && nginx -g "daemon off;"
+CMD /opt/start-nginx.sh

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build, see https://docs.docker.com/develop/develop-images/multistage-build/
 FROM alpine AS builder
 
-ENV VERSION 0.9.1
+ENV VERSION 0.9.2
 
 ADD https://github.com/sabre-io/Baikal/releases/download/$VERSION/baikal-$VERSION.zip .
 RUN apk add unzip && unzip -q baikal-$VERSION.zip
@@ -10,7 +10,7 @@ RUN apk add unzip && unzip -q baikal-$VERSION.zip
 FROM nginx:1
 
 LABEL description="Baikal is a Cal and CardDAV server, based on sabre/dav, that includes an administrative interface for easy management."
-LABEL version="0.9.1"
+LABEL version="0.9.2"
 LABEL repository="https://github.com/ckulka/baikal-docker"
 LABEL website="http://sabre.io/baikal/"
 
@@ -28,15 +28,18 @@ RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
     php8.0-mysql              \
     php8.0-sqlite3            \
     php8.0-xml                \
-    sqlite3                   \
-    msmtp msmtp-mta           &&\
+    sqlite3                   &&\
   rm -rf /var/lib/apt/lists/* &&\
   sed -i 's/www-data/nginx/' /etc/php/8.0/fpm/pool.d/www.conf &&\
   sed -i 's/^listen = .*/listen = \/var\/run\/php-fpm.sock/' /etc/php/8.0/fpm/pool.d/www.conf
 
 # Add Baikal & nginx configuration
 COPY --from=builder baikal /var/www/baikal
-RUN chown -R nginx:nginx /var/www/baikal
+RUN apt update \
+ && apt install -y \
+    msmtp msmtp-mta \
+ && rm -rf /var/lib/apt/lists/* \
+ && chown -R nginx:nginx /var/www/baikal
 COPY files/nginx.conf /etc/nginx/conf.d/default.conf
 COPY files/start*.sh /opt/
 


### PR DESCRIPTION
Move `apt install -y msmtp msmtp-mta` to final image because the binaries weren't copied over from the builder.

Caveat: I've only built/tested `nginx.dockerfile`, though I carried the update through to `nginx-php8.0.dockerfile`.  

- I noticed that `nginx-php8.0.dockerfile` still had `sendmail` being installed in the builder.  I removed because it seemed like the decision was to go with a pure `msmtp` setup, but I don't know if that's a valid assumption.
- I updated both of the `apache` images, but I haven't tested them.  I made the same changes -- moved `msmtp` and `msmtp-mta` to the final build, and removed `sendmail` from `apache-php8.0.dockerfile`