### PR TITLE
Fix permission problem at runtime level once and for all (allow switching between webserver without any action)

### DIFF
--- a/apache-php8.0.dockerfile
+++ b/apache-php8.0.dockerfile
@@ -15,9 +15,10 @@ LABEL repository="https://github.com/ckulka/baikal-docker"
 LABEL website="http://sabre.io/baikal/"
 
 # Install Baikal and required dependencies
-COPY --from=builder baikal /var/www/baikal
-RUN chown -R www-data:www-data /var/www/baikal      &&\
-  apt-get update                                    &&\
+RUN mkdir -p /usr/src/baikal
+COPY --from=builder baikal /usr/src/baikal
+
+RUN apt-get update                                  &&\
   apt-get install -y libcurl4-openssl-dev sendmail  &&\
   rm -rf /var/lib/apt/lists/*                       &&\
   docker-php-ext-install curl pdo pdo_mysql
@@ -32,4 +33,4 @@ VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific
 
 COPY files/start.sh /opt
-CMD [ "sh", "/opt/start.sh" ]
+ENTRYPOINT  [ "sh", "/opt/start.sh", "apache" ]

--- a/apache.dockerfile
+++ b/apache.dockerfile
@@ -15,9 +15,10 @@ LABEL repository="https://github.com/ckulka/baikal-docker"
 LABEL website="http://sabre.io/baikal/"
 
 # Install Baikal and required dependencies
-COPY --from=builder baikal /var/www/baikal
-RUN chown -R www-data:www-data /var/www/baikal      &&\
-  apt-get update                                    &&\
+RUN mkdir -p /usr/src/baikal
+COPY --from=builder baikal /usr/src/baikal
+
+RUN apt-get update                                  &&\
   apt-get install -y libcurl4-openssl-dev sendmail  &&\
   rm -rf /var/lib/apt/lists/*                       &&\
   docker-php-ext-install curl pdo pdo_mysql
@@ -32,4 +33,4 @@ VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific
 
 COPY files/start.sh /opt
-CMD [ "sh", "/opt/start.sh" ]
+ENTRYPOINT  [ "sh", "/opt/start.sh", "apache" ]

--- a/files/start.sh
+++ b/files/start.sh
@@ -1,15 +1,48 @@
 #!/bin/sh
 
-# Inject ServerName and ServerAlias if specified
-APACHE_CONFIG="/etc/apache2/sites-available/000-default.conf"
-if [ ! -z ${BAIKAL_SERVERNAME+x} ]
+echo "version : $1"
+
+cp -R /usr/src/baikal /var/www
+
+if ! [ -d /var/www/baikal/Specific/db ]
 then
+    mkdir -p/var/www/baikal/Specific/db
+fi
+
+if [ "$1" = "apache" ]
+then
+   echo "Starting Apache"
+   chown -R www-data:www-data /var/www/baikal
+
+   # Inject ServerName and ServerAlias if specified
+   APACHE_CONFIG="/etc/apache2/sites-available/000-default.conf"
+   if [ ! -z ${BAIKAL_SERVERNAME+x} ]
+   then
 	sed -i "s/# InjectedServerName .*/ServerName $BAIKAL_SERVERNAME/g" $APACHE_CONFIG
-fi
+   fi
 
-if [ ! -z ${BAIKAL_SERVERALIAS+x} ]
-then
+   if [ ! -z ${BAIKAL_SERVERALIAS+x} ]
+   then
 	sed -i "s/# InjectedServerAlias .*/ServerAlias $BAIKAL_SERVERALIAS/g" $APACHE_CONFIG
+   fi
+
+   apache2-foreground
 fi
 
-apache2-foreground
+if [ "$1" = "nginx" ]
+then
+    echo "Starting Nginx"
+    chown -R nginx:nginx /var/www/baikal
+
+    /etc/init.d/php8.1-fpm start && chown -R nginx:nginx /var/www/baikal/Specific && nginx -g "daemon off;"
+fi
+
+if [ "$1" = "nginx-php8.0" ]
+then
+    echo "Starting Nginx"
+    chown -R nginx:nginx /var/www/baikal
+
+    /etc/init.d/php8.0-fpm start && chown -R nginx:nginx /var/www/baikal/Specific && nginx -g "daemon off;"
+fi
+
+echo "done"

--- a/nginx-php8.0.dockerfile
+++ b/nginx-php8.0.dockerfile
@@ -15,6 +15,9 @@ LABEL repository="https://github.com/ckulka/baikal-docker"
 LABEL website="http://sabre.io/baikal/"
 
 # Install dependencies: PHP (with libffi6 dependency) & SQLite3
+RUN mkdir -p /usr/src/baikal
+COPY --from=builder baikal /usr/src/baikal
+
 RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg &&\
   apt update                  &&\
   apt install -y lsb-release  &&\
@@ -35,10 +38,11 @@ RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
   sed -i 's/^listen = .*/listen = \/var\/run\/php-fpm.sock/' /etc/php/8.0/fpm/pool.d/www.conf
 
 # Add Baikal & nginx configuration
-COPY --from=builder baikal /var/www/baikal
-RUN chown -R nginx:nginx /var/www/baikal
 COPY files/nginx.conf /etc/nginx/conf.d/default.conf
 
 VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific
-CMD /etc/init.d/php8.0-fpm start && chown -R nginx:nginx /var/www/baikal/Specific && nginx -g "daemon off;"
+
+COPY files/start.sh /opt
+ENTRYPOINT  [ "sh", "/opt/start.sh", "nginx-php8.0" ]
+

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -15,6 +15,9 @@ LABEL repository="https://github.com/ckulka/baikal-docker"
 LABEL website="http://sabre.io/baikal/"
 
 # Install dependencies: PHP (with libffi6 dependency) & SQLite3
+RUN mkdir -p /usr/src/baikal
+COPY --from=builder baikal /usr/src/baikal
+
 RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg &&\
   apt update                  &&\
   apt install -y lsb-release  &&\
@@ -35,10 +38,11 @@ RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
   sed -i 's/^listen = .*/listen = \/var\/run\/php-fpm.sock/' /etc/php/8.1/fpm/pool.d/www.conf
 
 # Add Baikal & nginx configuration
-COPY --from=builder baikal /var/www/baikal
-RUN chown -R nginx:nginx /var/www/baikal
 COPY files/nginx.conf /etc/nginx/conf.d/default.conf
 
 VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific
-CMD /etc/init.d/php8.1-fpm start && chown -R nginx:nginx /var/www/baikal/Specific && nginx -g "daemon off;"
+
+COPY files/start.sh /opt
+ENTRYPOINT  [ "sh", "/opt/start.sh", "nginx" ]
+


### PR DESCRIPTION
Hello
I was stuck with permission problem, no pre-creating the volumes or folders was working, no chmod/chown was working and I was stuck.
I compared with a dockerfile for roudcube that uses apache and sqlite and they did the image a bit differently, ie : they got the source package uncompressed in another folder (/usr/src/...) and they were using the entrypoint to copy the files in the /var/www folder then applying the permissions.

this take care of a lot of issue as the presented volume contain no data overwritten by the package
the folder are set to the correct permission before the webserver starts and after the docker started running
this apply the permission on the fly in the presented volumes allowing switching from nginx to apache without any action

changes made : 
- Docker Files now do unzip in /usr/src/baikal 
- Docker Files now run "ENTRYPOINT" instead of CMD to allow passing parameters, nginx now uses start.sh like apache
- start.sh is now taking a parameter that set which webserver is used
- it starts with the copy from src to www then depending on the parameter passed to the entrypoint it change permission and start the webserver

I tested the 4 dockerfile, I could swtich from any version without losing configuration or data