### PR TITLE
Fix msmtprc file permissions

### DIFF
--- a/files/docker-entrypoint.d/50-start-msmtp.sh
+++ b/files/docker-entrypoint.d/50-start-msmtp.sh
@@ -7,5 +7,5 @@ if [ ! -z ${MSMTPRC+x} ]
 then
   echo "$MSMTPRC" > /etc/msmtprc
   chown root:msmtp /etc/msmtprc
-  chmod 640 /etc/msmtprc
+  chmod 644 /etc/msmtprc
 fi


### PR DESCRIPTION
The nginx user was not able to access /etc/msmtprc, due to missing read permissions.