### PR TITLE
Replaced docker-compose with docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker run --rm -it -p 80:80 ckulka/baikal:nginx
 Alternatively, use the provided [examples/docker-compose.yaml](https://github.com/ckulka/baikal-docker/blob/master/examples/docker-compose.yaml) from the Git repository:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 You can now open [http://localhost](http://localhost) or [http://host-ip](http://host-ip) in your browser and use Baikal.

--- a/baikal.service
+++ b/baikal.service
@@ -5,9 +5,9 @@ After=docker
 
 [Service]
 WorkingDirectory=/etc/baikal
-ExecStart=/usr/local/bin/docker-compose up
-ExecReload=/usr/local/bin/docker-compose restart --force-recreate
-ExecStop=/usr/local/bin/docker-compose stop
+ExecStart=/usr/local/bin/docker compose up
+ExecReload=/usr/local/bin/docker compose restart --force-recreate
+ExecStop=/usr/local/bin/docker compose stop
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/docker-compose.awss3.yaml
+++ b/examples/docker-compose.awss3.yaml
@@ -26,8 +26,8 @@ services:
       - data:/mnt/Specific
     command: sh /opt/aws-s3-sync-backup.sh
 
-# To manually backup, run docker-compose run --rm backup
-# To manually restore, run docker-compose run --rm backup sh /opt/aws-s3-sync-restore.sh
+# To manually backup, run docker compose run --rm backup
+# To manually restore, run docker compose run --rm backup sh /opt/aws-s3-sync-restore.sh
 
 volumes:
   config:

--- a/examples/docker-compose.localvolumes.yaml
+++ b/examples/docker-compose.localvolumes.yaml
@@ -1,6 +1,6 @@
 # Docker Compose file for a Baikal server with local mounts instead of Docker volumes
 
-# Before you start docker-compose up, make sure that you have prepared
+# Before you start docker compose up, make sure that you have prepared
 # the local folders to avoid file permission issues with
 #
 # mkdir -p config Specific/db

--- a/examples/docker-compose.ssl.yaml
+++ b/examples/docker-compose.ssl.yaml
@@ -1,10 +1,10 @@
 # Docker Compose file for a Baikal server with Let's Encrypt using Traefik (https://docs.traefik.io/)
 #
-# The acme.json file must exist before you run docker-compose up.
+# The acme.json file must exist before you run docker compose up.
 #
 # 1. Adjust host in line 14
 # 2. Create acme.json: touch /etc/ssl/private/acme.json
-# 3. Start the stack: docker-compose -f docker-compose.ssl.yaml up
+# 3. Start the stack: docker compose -f docker compose.ssl.yaml up
 
 version: "2"
 services:


### PR DESCRIPTION
Replace references to the deprecated `docker-compose` command with the now recommended `docker compose`.

Addresses #157