### PR TITLE
Add pgsql PHP extensions

### DIFF
--- a/apache-php8.2.dockerfile
+++ b/apache-php8.2.dockerfile
@@ -14,9 +14,10 @@ COPY --from=builder --chown=www-data:www-data baikal /var/www/baikal
 RUN apt-get update            &&\
   apt-get install -y          \
     libcurl4-openssl-dev      \
-    msmtp msmtp-mta           &&\
+    msmtp msmtp-mta           \
+    libpq-dev                 &&\
   rm -rf /var/lib/apt/lists/* &&\
-  docker-php-ext-install curl pdo pdo_mysql
+  docker-php-ext-install curl pdo pdo_mysql pdo_pgsql pgsql
 
 # Configure Apache + HTTPS
 COPY files/apache.conf /etc/apache2/sites-enabled/000-default.conf

--- a/apache.dockerfile
+++ b/apache.dockerfile
@@ -14,9 +14,10 @@ COPY --from=builder --chown=www-data:www-data baikal /var/www/baikal
 RUN apt-get update            &&\
   apt-get install -y          \
     libcurl4-openssl-dev      \
-    msmtp msmtp-mta           &&\
+    msmtp msmtp-mta           \
+    libpq-dev                 &&\
   rm -rf /var/lib/apt/lists/* &&\
-  docker-php-ext-install curl pdo pdo_mysql
+  docker-php-ext-install curl pdo pdo_mysql pdo_pgsql pgsql
 
 # Configure Apache + HTTPS
 COPY files/apache.conf /etc/apache2/sites-enabled/000-default.conf


### PR DESCRIPTION
Fixes #256
Similar to #228

Without the right extensions, the docker image does not work out of the
box if a PostgreSQL backend is configured.