### PR TITLE
fix startup issue after container restart when home-assistant fix is enabled

### DIFF
--- a/files/docker-entrypoint.d/30-apply-home-assistant-fix.sh
+++ b/files/docker-entrypoint.d/30-apply-home-assistant-fix.sh
@@ -16,7 +16,7 @@ CHECKSUM="22e5ac3311fa112e702363920ce86d90256aacc6  /var/www/baikal/vendor/sabre
 if ! echo $CHECKSUM | sha1sum --check --status - ;
 then
   echo "$ME: info: Plugin.php differs from the packaged version"
-  exit 1
+  exit 0
 fi
 
 


### PR DESCRIPTION
This fixes an issue mentioned in #277 and in [#231](https://github.com/ckulka/baikal-docker/issues/231#issuecomment-2827325760).
The `exit 1` in [30-apply-home-assistant-fix.sh](https://github.com/ckulka/baikal-docker/blob/master/files/docker-entrypoint.d/30-apply-home-assistant-fix.sh), that triggers when the fix was already applied, will cause [docker-entrypoint.sh](https://github.com/ckulka/baikal-docker/blob/master/files/docker-entrypoint.sh) to exit the startup process because of `set -e`.