### PR TITLE
Add Mounted SSL Support to NGINX Image

### DIFF
--- a/docs/ssl-certificates-guide.md
+++ b/docs/ssl-certificates-guide.md
@@ -26,3 +26,10 @@ docker run --rm -it -p 80:80 -p 443:443 -v /etc/ssl/private/baikal:/etc/ssl/priv
 ```
 
 I also included the Docker Compose template [examples/docker-compose.apache.yaml](https://github.com/ckulka/baikal-docker/blob/master/examples/docker-compose.apache.yaml) for this scenario.
+
+If you're using the `nginx` variant and would like to mount your certificates, you can do something like this:
+
+```bash
+# The folder /etc/nginx/ssl contains the files nginx.crt and nginx.key
+docker run --rm -it -p 80:80 -p 443:443 -v /etc/ssl/private/baikal:/etc/nginx/ssl/:ro ckulka/baikal:nginx
+```

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -7,10 +7,13 @@ services:
     restart: always
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - config:/var/www/baikal/config
       - data:/var/www/baikal/Specific
+      - ssl:/etc/nginx/ssl
 
 volumes:
   config:
   data:
+  ssl:

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -3,6 +3,7 @@
 server {
   listen 80;
   listen [::]:80;
+  listen 443 ssl;
   server_name _;
 
   root   /var/www/baikal/html;
@@ -10,6 +11,9 @@ server {
 
   rewrite ^/.well-known/caldav /dav.php redirect;
   rewrite ^/.well-known/carddav /dav.php redirect;
+
+  ssl_certificate /etc/nginx/ssl/nginx.crt;
+  ssl_certificate_key /etc/nginx/ssl/nginx.key;
 
   charset utf-8;
 

--- a/nginx.dockerfile
+++ b/nginx.dockerfile
@@ -13,6 +13,7 @@ FROM nginx:1
 RUN curl -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg &&\
   apt update                  &&\
   apt install -y lsb-release  &&\
+  apt install -y libcurl4-openssl-dev      &&\
   echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list &&\
   apt remove -y lsb-release   &&\
   apt update                  &&\
@@ -35,5 +36,9 @@ COPY files/docker-entrypoint.d/*.sh files/docker-entrypoint.d/*.php files/docker
 COPY --from=builder --chown=nginx:nginx baikal /var/www/baikal
 COPY files/nginx.conf /etc/nginx/conf.d/default.conf
 
+RUN mkdir /etc/nginx/ssl
+RUN openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -subj "/C=/ST=/L=/O=/CN=" -keyout /etc/nginx/ssl/nginx.key -out /etc/nginx/ssl/nginx.crt
+
 VOLUME /var/www/baikal/config
 VOLUME /var/www/baikal/Specific
+VOLUME /etc/nginx/ssl


### PR DESCRIPTION
You can now mount an SSL certificate directory in the NGINX image similar to how you do it in the Apache image. By default, a CRT and KEY file is included in the image, but since it is generic, it might not play nice with some clients. It won't stop HTTP from working, but to get the best results with HTTPS, consider generating your own certificates and mounting them.