### PR TITLE
BREAKING CHANGE: Make file ownership opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ The image exposes the `/var/www/baikal/Specific` and `/var/www/baikal/config` fo
 
 If you want to use local folders instead of Docker volumes, see [examples/docker-compose.localvolumes.yaml](https://github.com/ckulka/baikal-docker/blob/master/examples/docker-compose.localvolumes.yaml) to avoid file permission issues.
 
-When the container starts, the startup script `/docker-entrypoint.d/40-fix-baikal-file-permissions.sh` ([Apache httpd](https://github.com/ckulka/baikal-docker/blob/master/files/docker-entrypoint.d/httpd/40-fix-baikal-file-permissions.sh), [nginx](https://github.com/ckulka/baikal-docker/blob/master/files/docker-entrypoint.d/nginx/40-fix-baikal-file-permissions.sh)) ensures that the file permissions are correct. You can disable this behaviour by setting the environment variable `BAIKAL_SKIP_CHOWN` to any value, e.g. `FALSE`.
-
 ### Further Guides
 
 You can find more installation and configuration guides here:

--- a/examples/docker-compose.localvolumes.yaml
+++ b/examples/docker-compose.localvolumes.yaml
@@ -6,6 +6,10 @@
 # mkdir -p config Specific/db
 # chown -R 101:101 config Specific  <- Use this for Nginx
 # chown -R 33:33 config Specific    <- Use this for Apache httpd
+#
+# If you cannot use the user ids above on your host, re-map the container's
+# user ids to the user ids you can use on your host. For more details, see
+# https://docs.docker.com/engine/security/userns-remap/.
 
 version: "2"
 services:
@@ -14,6 +18,10 @@ services:
     restart: always
     ports:
       - "80:80"
+    # Use this flag if you can use the default user ids (see above) and want to
+    # ensure correct file permissions every time the container starts.
+    # environment:
+    #   BAIKAL_ENABLE_CHOWN: "1"
     volumes:
       - ./config:/var/www/baikal/config
       - ./Specific:/var/www/baikal/Specific

--- a/files/docker-entrypoint.d/httpd/40-fix-baikal-file-permissions.sh
+++ b/files/docker-entrypoint.d/httpd/40-fix-baikal-file-permissions.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-# Ensure correct file permissions, unless behaviour is explicitly disabled
-if [ -z ${BAIKAL_SKIP_CHOWN+x} ]
+# Ensure correct file permissions if flag is set
+if [ ! -z ${BAIKAL_ENABLE_CHOWN+x} ]
 then
   chown -R www-data:www-data /var/www/baikal
 fi

--- a/files/docker-entrypoint.d/nginx/40-fix-baikal-file-permissions.sh
+++ b/files/docker-entrypoint.d/nginx/40-fix-baikal-file-permissions.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
-# Ensure correct file permissions, unless behaviour is explicitly disabled
-if [ -z ${BAIKAL_SKIP_CHOWN+x} ]
+# Ensure correct file permissions if flag is set
+if [ ! -z ${BAIKAL_ENABLE_CHOWN+x} ]
 then
   chown -R nginx:nginx /var/www/baikal
 fi
+


### PR DESCRIPTION
This PR stops changing the file ownership of the Baikal folder upon container start.

This used to be required to ensure local volumes on the host have the correct permissions set and that the user id of nginx/httpd can access them. Nowadays though, the recommended approach is user re-mapping, see https://docs.docker.com/engine/security/userns-remap/.

Only breaking change as it changes default behaviour. Functionality is still available and can be enabled if required.