### PR TITLE
Adjusting nginx rewrite rules to avoid sync issues when using a different port or non-ssl setups.

### DIFF
--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -8,8 +8,8 @@ server {
   root   /var/www/baikal/html;
   index index.php;
 
-  rewrite ^/.well-known/caldav /dav.php redirect;
-  rewrite ^/.well-known/carddav /dav.php redirect;
+  rewrite ^/.well-known/caldav $scheme://$http_host/dav.php redirect;
+  rewrite ^/.well-known/carddav $scheme://$http_host/dav.php redirect;
 
   charset utf-8;
 


### PR DESCRIPTION
This PR aims to fix sync issues linked to the [default nginx config](https://github.com/ckulka/baikal-docker/blob/master/files/nginx.conf) when using a different port than 80 or non-ssl setups (local network test or home-only usage).

I encountered sync issues when testing calendar syncs iOS in two situations:
- When I changed the exposed port to one different from 80 using docker port mapping, which caused a redirection issue because the port is not kept in the redirection therefore attempting to reach the default http(s) port (fixed with the `$http_host` variable).
  - [Latest issue about port redirection](https://github.com/ckulka/baikal-docker/blob/master/files/nginx.conf)
  - [Issue about using a different port](https://github.com/ckulka/baikal-docker/issues/283)
  - [Possibly related issue](https://github.com/ckulka/baikal-docker/issues/25)
- When the setup is not using a domain or ssl (for example for a local network usage at home) sync issues can happen because of a http to https rewrite by the system/software used (fixed with the `$scheme` variable).
  - [Some issue I stumbled upon when debugging](https://github.com/sabre-io/Baikal/issues/1168)
  - [Related issue](https://github.com/sabre-io/Baikal/issues/1168)

