### PR TITLE
Remove obsolete attribute "version" in all docker-compose.yml files

### DIFF
--- a/examples/docker-compose.apache.yaml
+++ b/examples/docker-compose.apache.yaml
@@ -1,5 +1,3 @@
-version: "2"
-
 services:
   baikal:
     image: ckulka/baikal:apache

--- a/examples/docker-compose.awss3.yaml
+++ b/examples/docker-compose.awss3.yaml
@@ -1,5 +1,3 @@
-version: "2"
-
 services:
   baikal:
     image: ckulka/baikal:nginx

--- a/examples/docker-compose.custom-storage-location.yaml
+++ b/examples/docker-compose.custom-storage-location.yaml
@@ -1,6 +1,5 @@
 # Docker Compose file for a Baikal server
 
-version: "2"
 services:
   baikal:
     image: ckulka/baikal:nginx

--- a/examples/docker-compose.email-gmail.yaml
+++ b/examples/docker-compose.email-gmail.yaml
@@ -1,7 +1,6 @@
 # Docker Compose file for a Baikal server
 # See https://github.com/ckulka/baikal-docker/blob/master/docs/email-guide.md
 
-version: "2"
 services:
   baikal:
     image: ckulka/baikal:nginx

--- a/examples/docker-compose.email.yaml
+++ b/examples/docker-compose.email.yaml
@@ -1,7 +1,6 @@
 # Docker Compose file for a Baikal server
 # See https://github.com/ckulka/baikal-docker/blob/master/docs/email-guide.md
 
-version: "2"
 services:
   baikal:
     image: ckulka/baikal:nginx

--- a/examples/docker-compose.localvolumes.yaml
+++ b/examples/docker-compose.localvolumes.yaml
@@ -7,7 +7,6 @@
 # chown -R 101:101 config Specific  <- Use this for Nginx
 # chown -R 33:33 config Specific    <- Use this for Apache httpd
 
-version: "2"
 services:
   baikal:
     image: ckulka/baikal:nginx

--- a/examples/docker-compose.mariadb.yaml
+++ b/examples/docker-compose.mariadb.yaml
@@ -1,7 +1,6 @@
 # Docker Compose file for a Baikal server with MariaDB 5
 # Based on issue https://github.com/ckulka/baikal-docker/issues/10
 
-version: "2"
 services:
   baikal:
     image: ckulka/baikal:nginx

--- a/examples/docker-compose.ssl.yaml
+++ b/examples/docker-compose.ssl.yaml
@@ -7,7 +7,6 @@
 # 3. Adjust file permissions: chmod 600 /etc/ssl/private/acme.json
 # 4. Start the stack: docker compose -f docker compose.ssl.yaml up
 
-version: "2"
 services:
   baikal:
     image: ckulka/baikal:nginx

--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,6 +1,5 @@
 # Docker Compose file for a Baikal server
 
-version: "2"
 services:
   baikal:
     image: ckulka/baikal:nginx


### PR DESCRIPTION
Since this project doesn't use old docker-compose it's time to remove attribute "version" from all docker-compose.yml files because now it doesn't change anything. Fixes #302 